### PR TITLE
refactor(api,web): Use DB models internally

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -2,7 +2,7 @@ name: Conventional Commits
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -13,4 +13,4 @@ jobs:
 
       - uses: webiny/action-conventional-commits@v1.3.0
         with:
-          allowed-commit-types: "chore,ci,docs,feat,fix"
+          allowed-commit-types: "chore,ci,docs,feat,fix,refactor"

--- a/api.yaml
+++ b/api.yaml
@@ -17,6 +17,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ModelCollection"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    post:
+      summary: Create model
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewModel"
+      responses:
+        "201":
+          description: Model created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Model"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
   /models/{modelID}:
     parameters:
@@ -37,11 +61,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/Model"
         "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
     put:
       requestBody:
@@ -58,28 +80,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Model"
         "400":
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/InvalidRequest"
         "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
     delete:
       responses:
         "204":
           description: Model deleted
         "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
   /vendors:
     get:
@@ -90,6 +104,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VendorCollection"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
     post:
       requestBody:
@@ -107,11 +123,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vendor"
         "400":
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/InvalidRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
   /vendors/{vendorID}:
     parameters:
@@ -131,22 +145,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vendor"
         "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
     delete:
       responses:
         "204":
           description: Vendor deleted
         "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
   /vendors/{vendorID}/models:
     parameters:
@@ -168,41 +178,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/ModelCollection"
         "404":
-          description: Vendor not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-
-    post:
-      summary: Add vendor model
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/NewModel"
-      responses:
-        "201":
-          description: Model created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Model"
-        "400":
-          description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
-        "404":
-          description: Missing vendor
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIError"
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
 components:
+  responses:
+    InvalidRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIError"
+
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIError"
+
+    ServerError:
+      description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIError"
+
   schemas:
     Model:
       type: object
@@ -240,6 +242,7 @@ components:
       type: object
       required:
         - model
+        - vendorID
       properties:
         model:
           type: string
@@ -248,14 +251,18 @@ components:
           type: string
           description: A readable name for the vendor.
           example: Acme Inc.
+        vendorID:
+          type: integer
+          description: The ID of the vendor that produces the model.
+          example: 36
 
     Vendor:
       type: object
       required:
         - id
         - name
-        - created_at
-        - updated_at
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: integer
@@ -264,11 +271,11 @@ components:
           type: string
           description: A readable name for the vendor.
           example: Acme Inc.
-        created_at:
+        createdAt:
           type: string
           format: date-time
           description: The instant the vendor was added to the system.
-        updated_at:
+        updatedAt:
           type: string
           format: date-time
           description: The instant the vendor's information was last updated.
@@ -283,8 +290,6 @@ components:
           description: A readable name for the vendor.
           example: Acme Inc.
           pattern: '^\s{1,150}$'
-          x-oapi-codegen-extra-tags:
-            validate: "required,min=1,max=150"
 
     ModelCollection:
       type: object

--- a/api/internal/api/model_impl.go
+++ b/api/internal/api/model_impl.go
@@ -3,53 +3,107 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 
-	"github.com/cdriehuys/stuff/api/internal/apierrors"
+	"github.com/cdriehuys/stuff/api/internal/models"
+	"github.com/go-playground/validator/v10"
 )
 
 func (s *Server) GetModels(ctx context.Context, req GetModelsRequestObject) (GetModelsResponseObject, error) {
 	models, err := s.models.ListModels(ctx)
 	if err != nil {
-		return GetModels200JSONResponse{}, fmt.Errorf("failed to list models: %v", err)
+		s.logger.ErrorContext(ctx, "Failed to list models.", "error", err)
+		return GetModels500JSONResponse{}, nil
 	}
 
-	return GetModels200JSONResponse{Items: models}, nil
+	return GetModels200JSONResponse(modelCollection(models)), nil
+}
+
+func (s *Server) PostModels(ctx context.Context, req PostModelsRequestObject) (PostModelsResponseObject, error) {
+	model := internalNewModel(*req.Body)
+	newModel, err := s.models.Create(ctx, model)
+	if err != nil {
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			return PostModels400JSONResponse{InvalidRequestJSONResponse(validationError(ve))}, nil
+		}
+
+		s.logger.ErrorContext(ctx, "Failed to create model.", "error", err)
+		return PostModels500JSONResponse{}, nil
+	}
+
+	return PostModels201JSONResponse(externalModel(newModel)), nil
 }
 
 func (s *Server) GetModelsModelID(ctx context.Context, req GetModelsModelIDRequestObject) (GetModelsModelIDResponseObject, error) {
 	model, err := s.models.GetByID(ctx, int64(req.ModelID))
 	if err != nil {
-		return GetModelsModelID200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to get model by ID.", "error", "err", "modelID", req.ModelID)
+		return GetModelsModelID500JSONResponse{}, nil
 	}
 
-	return GetModelsModelID200JSONResponse(model), nil
+	return GetModelsModelID200JSONResponse(externalModel(model)), nil
 }
 
 func (s *Server) PutModelsModelID(ctx context.Context, req PutModelsModelIDRequestObject) (PutModelsModelIDResponseObject, error) {
-	model, err := s.models.UpdateByID(ctx, int64(req.ModelID), *req.Body)
+	update := internalNewModel(*req.Body)
+	model, err := s.models.UpdateByID(ctx, int64(req.ModelID), update)
 	if err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
+		if errors.Is(err, models.ErrNotFound) {
 			message := "Model does not exist."
-			return PutModelsModelID404JSONResponse{Message: &message}, nil
+			return PutModelsModelID404JSONResponse{NotFoundJSONResponse{Message: &message}}, nil
 		}
 
-		return PutModelsModelID200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to update model.", "error", err, "modelID", req.ModelID)
+		return PutModelsModelID500JSONResponse{}, nil
 	}
 
-	return PutModelsModelID200JSONResponse(model), nil
+	return PutModelsModelID200JSONResponse(externalModel(model)), nil
 }
 
 func (s *Server) DeleteModelsModelID(ctx context.Context, req DeleteModelsModelIDRequestObject) (DeleteModelsModelIDResponseObject, error) {
 	err := s.models.DeleteByID(ctx, int64(req.ModelID))
 	if err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
+		if errors.Is(err, models.ErrNotFound) {
 			message := "Model does not exist."
-			return DeleteModelsModelID404JSONResponse{Message: &message}, nil
+			return DeleteModelsModelID404JSONResponse{NotFoundJSONResponse{Message: &message}}, nil
 		}
 
-		return DeleteModelsModelID204Response{}, err
+		s.logger.ErrorContext(ctx, "Failed to delete model.", "error", err, "modelID", req.ModelID)
+		return DeleteModelsModelID500JSONResponse{}, nil
 	}
 
 	return DeleteModelsModelID204Response{}, nil
+}
+
+func externalModel(model models.Model) Model {
+	return Model{
+		CreatedAt: model.CreatedAt,
+		Id:        int(model.ID),
+		Model:     model.Model,
+		Name:      model.Name,
+		UpdatedAt: model.UpdatedAt,
+		VendorID:  int(model.VendorID),
+	}
+}
+
+func modelCollection(models []models.Model) ModelCollection {
+	reps := make([]Model, len(models))
+	for i, model := range models {
+		reps[i] = externalModel(model)
+	}
+
+	return ModelCollection{Items: reps}
+}
+
+func internalNewModel(model NewModel) models.NewModel {
+	internal := models.NewModel{
+		VendorID: int64(model.VendorID),
+		Model:    model.Model,
+	}
+
+	if model.Name != nil {
+		internal.Name = *model.Name
+	}
+
+	return internal
 }

--- a/api/internal/api/server.go
+++ b/api/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/cdriehuys/stuff/api/internal/models"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -13,19 +14,19 @@ import (
 var _ StrictServerInterface = (*Server)(nil)
 
 type modelModel interface {
-	Create(ctx context.Context, vendorID int64, model NewModel) (Model, error)
+	Create(ctx context.Context, model models.NewModel) (models.Model, error)
 	DeleteByID(ctx context.Context, id int64) error
-	GetByID(ctx context.Context, id int64) (Model, error)
-	ListByVendorID(ctx context.Context, vendorID int64) ([]Model, error)
-	ListModels(ctx context.Context) ([]Model, error)
-	UpdateByID(ctx context.Context, id int64, model NewModel) (Model, error)
+	GetByID(ctx context.Context, id int64) (models.Model, error)
+	ListByVendorID(ctx context.Context, vendorID int64) ([]models.Model, error)
+	ListModels(ctx context.Context) ([]models.Model, error)
+	UpdateByID(ctx context.Context, id int64, model models.NewModel) (models.Model, error)
 }
 
 type vendorModel interface {
-	Create(ctx context.Context, vendor NewVendor) (Vendor, error)
+	Create(ctx context.Context, vendor models.NewVendor) (models.Vendor, error)
 	DeleteByID(ctx context.Context, id int64) error
-	GetByID(ctx context.Context, id int64) (Vendor, error)
-	ListVendors(ctx context.Context) ([]Vendor, error)
+	GetByID(ctx context.Context, id int64) (models.Vendor, error)
+	ListVendors(ctx context.Context) ([]models.Vendor, error)
 }
 
 type Server struct {

--- a/api/internal/api/vendor_impl.go
+++ b/api/internal/api/vendor_impl.go
@@ -5,56 +5,60 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cdriehuys/stuff/api/internal/apierrors"
+	"github.com/cdriehuys/stuff/api/internal/models"
+	"github.com/go-playground/validator/v10"
 )
 
 func (s *Server) GetVendors(ctx context.Context, req GetVendorsRequestObject) (GetVendorsResponseObject, error) {
 	vendors, err := s.vendors.ListVendors(ctx)
 	if err != nil {
-		return GetVendors200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to list vendors.", "error", err)
+		return GetVendors500JSONResponse{}, nil
 	}
 
-	return GetVendors200JSONResponse{Items: vendors}, nil
+	return GetVendors200JSONResponse(vendorCollection(vendors)), nil
 }
 
 func (s *Server) PostVendors(ctx context.Context, req PostVendorsRequestObject) (PostVendorsResponseObject, error) {
-	newVendor := NewVendor(*req.Body)
-
-	if err := s.validate.Struct(newVendor); err != nil {
-		s.logger.DebugContext(ctx, "Invalid new vendor.", "error", err)
-
-		return PostVendors400JSONResponse(validationError(err)), nil
-	}
+	newVendor := internalNewVendor(*req.Body)
 
 	vendor, err := s.vendors.Create(ctx, newVendor)
 	if err != nil {
-		return PostVendors201JSONResponse{}, err
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			return PostVendors400JSONResponse{InvalidRequestJSONResponse(validationError(ve))}, nil
+		}
+
+		s.logger.ErrorContext(ctx, "Failed to create vendor.", "error", err)
+		return PostVendors500JSONResponse{}, nil
 	}
 
-	return PostVendors201JSONResponse(vendor), nil
+	return PostVendors201JSONResponse(externalVendor(vendor)), nil
 }
 
 func (s *Server) GetVendorsVendorID(ctx context.Context, req GetVendorsVendorIDRequestObject) (GetVendorsVendorIDResponseObject, error) {
 	vendor, err := s.vendors.GetByID(ctx, int64(req.VendorID))
 	if err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
+		if errors.Is(err, models.ErrNotFound) {
 			message := fmt.Sprintf("No vendor with ID %d.", req.VendorID)
-			return GetVendorsVendorID404JSONResponse{Message: &message}, nil
+			return GetVendorsVendorID404JSONResponse{NotFoundJSONResponse{Message: &message}}, nil
 		}
 
-		return GetVendorsVendorID200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to get vendor by ID.", "error", err, "vendorID", req.VendorID)
+		return GetVendorsVendorID500JSONResponse{}, nil
 	}
 
-	return GetVendorsVendorID200JSONResponse(vendor), nil
+	return GetVendorsVendorID200JSONResponse(externalVendor(vendor)), nil
 }
 
 func (s *Server) DeleteVendorsVendorID(ctx context.Context, req DeleteVendorsVendorIDRequestObject) (DeleteVendorsVendorIDResponseObject, error) {
 	if err := s.vendors.DeleteByID(ctx, int64(req.VendorID)); err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
+		if errors.Is(err, models.ErrNotFound) {
 			return DeleteVendorsVendorID404JSONResponse{}, nil
 		}
 
-		return DeleteVendorsVendorID204Response{}, fmt.Errorf("failed to delete vendor: %v", err)
+		s.logger.ErrorContext(ctx, "Failed to delete vendor.", "error", err, "vendorID", req.VendorID)
+		return DeleteVendorsVendorID500JSONResponse{}, nil
 	}
 
 	return DeleteVendorsVendorID204Response{}, nil
@@ -63,34 +67,46 @@ func (s *Server) DeleteVendorsVendorID(ctx context.Context, req DeleteVendorsVen
 func (s *Server) GetVendorsVendorIDModels(ctx context.Context, req GetVendorsVendorIDModelsRequestObject) (GetVendorsVendorIDModelsResponseObject, error) {
 	_, err := s.vendors.GetByID(ctx, int64(req.VendorID))
 	if err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
+		if errors.Is(err, models.ErrNotFound) {
 			message := "Vendor does not exist."
-			return GetVendorsVendorIDModels404JSONResponse{Message: &message}, nil
+			return GetVendorsVendorIDModels404JSONResponse{NotFoundJSONResponse{Message: &message}}, nil
 		}
 
-		return GetVendorsVendorIDModels200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to get vendor.", "error", err, "vendorID", req.VendorID)
+		return GetVendorsVendorIDModels500JSONResponse{}, nil
 	}
 
 	s.logger.DebugContext(ctx, "Vendor exists.", "vendorID", req.VendorID)
 
 	models, err := s.models.ListByVendorID(ctx, int64(req.VendorID))
 	if err != nil {
-		return GetVendorsVendorIDModels200JSONResponse{}, err
+		s.logger.ErrorContext(ctx, "Failed to get models for vendor.", "error", err, "vendorID", req.VendorID)
+		return GetVendorsVendorIDModels500JSONResponse{}, nil
 	}
 
-	return GetVendorsVendorIDModels200JSONResponse{Items: models}, nil
+	return GetVendorsVendorIDModels200JSONResponse(modelCollection(models)), nil
 }
 
-func (s *Server) PostVendorsVendorIDModels(ctx context.Context, req PostVendorsVendorIDModelsRequestObject) (PostVendorsVendorIDModelsResponseObject, error) {
-	newModel, err := s.models.Create(ctx, int64(req.VendorID), *req.Body)
-	if err != nil {
-		if errors.Is(err, apierrors.ErrNotFound) {
-			message := fmt.Sprintf("No vendor with ID %d.", req.VendorID)
-			return PostVendorsVendorIDModels404JSONResponse{Message: &message}, nil
-		}
+func externalVendor(vendor models.Vendor) Vendor {
+	return Vendor{
+		CreatedAt: vendor.CreatedAt,
+		Id:        int(vendor.ID),
+		Name:      vendor.Name,
+		UpdatedAt: vendor.UpdatedAt,
+	}
+}
 
-		return PostVendorsVendorIDModels201JSONResponse{}, err
+func vendorCollection(vendors []models.Vendor) VendorCollection {
+	reps := make([]Vendor, len(vendors))
+	for i, vendor := range vendors {
+		reps[i] = externalVendor(vendor)
 	}
 
-	return PostVendorsVendorIDModels201JSONResponse(newModel), nil
+	return VendorCollection{Items: reps}
+}
+
+func internalNewVendor(vendor NewVendor) models.NewVendor {
+	return models.NewVendor{
+		Name: vendor.Name,
+	}
 }

--- a/api/internal/apierrors/errors.go
+++ b/api/internal/apierrors/errors.go
@@ -1,6 +1,0 @@
-package apierrors
-
-import "errors"
-
-// ErrNotFound indicates an expected resource was not found.
-var ErrNotFound = errors.New("not found")

--- a/api/internal/models/errors.go
+++ b/api/internal/models/errors.go
@@ -1,0 +1,11 @@
+package models
+
+import (
+	"errors"
+)
+
+// ErrNotFound indicates the resource being queried for does not exist.
+var ErrNotFound = errors.New("not found")
+
+// ErrVendorNotFound indicates that the referenced vendor does not exist.
+var ErrVendorNotFound = errors.New("vendor not found")

--- a/api/internal/models/models.go
+++ b/api/internal/models/models.go
@@ -5,30 +5,48 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
-	"github.com/cdriehuys/stuff/api/internal/api"
-	"github.com/cdriehuys/stuff/api/internal/apierrors"
 	"github.com/cdriehuys/stuff/api/internal/models/queries"
+	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+type NewModel struct {
+	VendorID int64  `json:"vendorID"`
+	Model    string `json:"model" validate:"required,min=1,max=150"`
+	Name     string `json:"name" validate:"max=150"`
+}
+
+type Model struct {
+	ID        int64
+	VendorID  int64
+	Model     string
+	Name      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 type ModelModel struct {
-	logger *slog.Logger
-	q      *queries.Queries
+	logger   *slog.Logger
+	q        *queries.Queries
+	validate *validator.Validate
 }
 
-func NewModelModel(logger *slog.Logger, db queries.DBTX) *ModelModel {
-	return &ModelModel{logger: logger, q: queries.New(db)}
+func NewModelModel(logger *slog.Logger, db queries.DBTX, validate *validator.Validate) *ModelModel {
+	return &ModelModel{logger: logger, q: queries.New(db), validate: validate}
 }
 
-func (m *ModelModel) Create(ctx context.Context, vendorID int64, model api.NewModel) (api.Model, error) {
+func (m *ModelModel) Create(ctx context.Context, model NewModel) (Model, error) {
+	if err := m.validate.Struct(model); err != nil {
+		return Model{}, err
+	}
+
 	args := queries.CreateModelParams{
 		Model:    model.Model,
-		VendorID: vendorID,
-	}
-	if model.Name != nil {
-		args.Name = *model.Name
+		VendorID: model.VendorID,
+		Name:     model.Name,
 	}
 
 	row, err := m.q.CreateModel(ctx, args)
@@ -37,14 +55,14 @@ func (m *ModelModel) Create(ctx context.Context, vendorID int64, model api.NewMo
 		if errors.As(err, &pgErr) {
 			// foreign_key_violation
 			if pgErr.Code == "23503" {
-				return api.Model{}, fmt.Errorf("failed to add model for vendor %d: %w", vendorID, apierrors.ErrNotFound)
+				return Model{}, fmt.Errorf("failed to add model for vendor %d: %w", model.VendorID, ErrNotFound)
 			}
 		}
 
-		return api.Model{}, fmt.Errorf("failed to create model: %v", err)
+		return Model{}, fmt.Errorf("failed to create model: %v", err)
 	}
 
-	m.logger.InfoContext(ctx, "Created model for vendor.", "vendorID", vendorID, "modelID", row.ID)
+	m.logger.InfoContext(ctx, "Created model.", "modelID", row.ID)
 
 	return modelFromRow(row), nil
 }
@@ -56,7 +74,7 @@ func (m *ModelModel) DeleteByID(ctx context.Context, id int64) error {
 	}
 
 	if rows == 0 {
-		return fmt.Errorf("no model deleted: %w", apierrors.ErrNotFound)
+		return fmt.Errorf("no model deleted: %w", ErrNotFound)
 	}
 
 	m.logger.InfoContext(ctx, "Deleted model.", "id", id)
@@ -64,26 +82,26 @@ func (m *ModelModel) DeleteByID(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (m *ModelModel) GetByID(ctx context.Context, id int64) (api.Model, error) {
+func (m *ModelModel) GetByID(ctx context.Context, id int64) (Model, error) {
 	row, err := m.q.GetModelByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return api.Model{}, fmt.Errorf("no model with ID %d: %w", id, apierrors.ErrNotFound)
+			return Model{}, fmt.Errorf("no model with ID %d: %w", id, ErrNotFound)
 		}
 
-		return api.Model{}, fmt.Errorf("failed to retrieve model: %v", err)
+		return Model{}, fmt.Errorf("failed to retrieve model: %v", err)
 	}
 
 	return modelFromRow(row), nil
 }
 
-func (m *ModelModel) ListByVendorID(ctx context.Context, vendorID int64) ([]api.Model, error) {
+func (m *ModelModel) ListByVendorID(ctx context.Context, vendorID int64) ([]Model, error) {
 	rows, err := m.q.ListModelsByVendorID(ctx, vendorID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list models: %v", err)
 	}
 
-	models := make([]api.Model, len(rows))
+	models := make([]Model, len(rows))
 	for i, row := range rows {
 		models[i] = modelFromRow(row)
 	}
@@ -91,13 +109,13 @@ func (m *ModelModel) ListByVendorID(ctx context.Context, vendorID int64) ([]api.
 	return models, nil
 }
 
-func (m *ModelModel) ListModels(ctx context.Context) ([]api.Model, error) {
+func (m *ModelModel) ListModels(ctx context.Context) ([]Model, error) {
 	rows, err := m.q.ListModels(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list models: %v", err)
 	}
 
-	models := make([]api.Model, len(rows))
+	models := make([]Model, len(rows))
 	for i, row := range rows {
 		models[i] = modelFromRow(row)
 	}
@@ -105,31 +123,33 @@ func (m *ModelModel) ListModels(ctx context.Context) ([]api.Model, error) {
 	return models, nil
 }
 
-func (m *ModelModel) UpdateByID(ctx context.Context, id int64, model api.NewModel) (api.Model, error) {
-	args := queries.UpdateModelByIDParams{ID: id, Model: model.Model}
-	if model.Name != nil {
-		args.Name = *model.Name
+func (m *ModelModel) UpdateByID(ctx context.Context, id int64, model NewModel) (Model, error) {
+	args := queries.UpdateModelByIDParams{
+		ID:       id,
+		Model:    model.Model,
+		Name:     model.Name,
+		VendorID: model.VendorID,
 	}
 
 	row, err := m.q.UpdateModelByID(ctx, args)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return api.Model{}, fmt.Errorf("no model with ID %d: %w", id, apierrors.ErrNotFound)
+			return Model{}, fmt.Errorf("no model with ID %d: %w", id, ErrNotFound)
 		}
 
-		return api.Model{}, fmt.Errorf("failed to update model: %v", err)
+		return Model{}, fmt.Errorf("failed to update model: %v", err)
 	}
 
 	return modelFromRow(row), nil
 }
 
-func modelFromRow(row queries.Model) api.Model {
-	return api.Model{
+func modelFromRow(row queries.Model) Model {
+	return Model{
 		CreatedAt: row.CreatedAt.Time,
-		Id:        int(row.ID),
+		ID:        row.ID,
 		Model:     row.Model,
 		Name:      row.Name,
 		UpdatedAt: row.UpdatedAt.Time,
-		VendorID:  int(row.VendorID),
+		VendorID:  row.VendorID,
 	}
 }

--- a/api/internal/models/queries/models.sql
+++ b/api/internal/models/queries/models.sql
@@ -20,6 +20,6 @@ ORDER BY id LIMIT 50;
 
 -- name: UpdateModelByID :one
 UPDATE models
-SET model = $2, name = $3
+SET vendor_id = @vendor_id, model = $2, name = $3
 WHERE id = $1
 RETURNING *;

--- a/api/internal/models/queries/models.sql.gen.go
+++ b/api/internal/models/queries/models.sql.gen.go
@@ -132,19 +132,25 @@ func (q *Queries) ListModelsByVendorID(ctx context.Context, vendorID int64) ([]M
 
 const updateModelByID = `-- name: UpdateModelByID :one
 UPDATE models
-SET model = $2, name = $3
+SET vendor_id = $4, model = $2, name = $3
 WHERE id = $1
 RETURNING id, model, vendor_id, name, created_at, updated_at
 `
 
 type UpdateModelByIDParams struct {
-	ID    int64
-	Model string
-	Name  string
+	ID       int64
+	Model    string
+	Name     string
+	VendorID int64
 }
 
 func (q *Queries) UpdateModelByID(ctx context.Context, arg UpdateModelByIDParams) (Model, error) {
-	row := q.db.QueryRow(ctx, updateModelByID, arg.ID, arg.Model, arg.Name)
+	row := q.db.QueryRow(ctx, updateModelByID,
+		arg.ID,
+		arg.Model,
+		arg.Name,
+		arg.VendorID,
+	)
 	var i Model
 	err := row.Scan(
 		&i.ID,

--- a/web/api/api.d.ts
+++ b/web/api/api.d.ts
@@ -29,10 +29,38 @@ export interface paths {
                         "application/json": components["schemas"]["ModelCollection"];
                     };
                 };
+                500: components["responses"]["ServerError"];
             };
         };
         put?: never;
-        post?: never;
+        /** Create model */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["NewModel"];
+                };
+            };
+            responses: {
+                /** @description Model created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Model"];
+                    };
+                };
+                400: components["responses"]["InvalidRequest"];
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -68,15 +96,8 @@ export interface paths {
                         "application/json": components["schemas"]["Model"];
                     };
                 };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         put: {
@@ -103,24 +124,9 @@ export interface paths {
                         "application/json": components["schemas"]["Model"];
                     };
                 };
-                /** @description Invalid request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                400: components["responses"]["InvalidRequest"];
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         post?: never;
@@ -142,15 +148,8 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         options?: never;
@@ -183,6 +182,7 @@ export interface paths {
                         "application/json": components["schemas"]["VendorCollection"];
                     };
                 };
+                500: components["responses"]["ServerError"];
             };
         };
         put?: never;
@@ -208,15 +208,8 @@ export interface paths {
                         "application/json": components["schemas"]["Vendor"];
                     };
                 };
-                /** @description Invalid request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                400: components["responses"]["InvalidRequest"];
+                500: components["responses"]["ServerError"];
             };
         };
         delete?: never;
@@ -254,15 +247,8 @@ export interface paths {
                         "application/json": components["schemas"]["Vendor"];
                     };
                 };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         put?: never;
@@ -285,15 +271,8 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         options?: never;
@@ -331,63 +310,12 @@ export interface paths {
                         "application/json": components["schemas"]["ModelCollection"];
                     };
                 };
-                /** @description Vendor not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
+                404: components["responses"]["NotFound"];
+                500: components["responses"]["ServerError"];
             };
         };
         put?: never;
-        /** Add vendor model */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    vendorID: number;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["NewModel"];
-                };
-            };
-            responses: {
-                /** @description Model created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Model"];
-                    };
-                };
-                /** @description Invalid request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
-                /** @description Missing vendor */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["APIError"];
-                    };
-                };
-            };
-        };
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -429,6 +357,11 @@ export interface components {
              * @example Acme Inc.
              */
             name?: string;
+            /**
+             * @description The ID of the vendor that produces the model.
+             * @example 36
+             */
+            vendorID: number;
         };
         Vendor: {
             /** @description A unique identifier for the vendor. */
@@ -442,12 +375,12 @@ export interface components {
              * Format: date-time
              * @description The instant the vendor was added to the system.
              */
-            created_at: string;
+            createdAt: string;
             /**
              * Format: date-time
              * @description The instant the vendor's information was last updated.
              */
-            updated_at: string;
+            updatedAt: string;
         };
         NewVendor: {
             /**
@@ -484,7 +417,35 @@ export interface components {
             message: string;
         };
     };
-    responses: never;
+    responses: {
+        /** @description Invalid request */
+        InvalidRequest: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["APIError"];
+            };
+        };
+        /** @description Not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["APIError"];
+            };
+        };
+        /** @description Server error */
+        ServerError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["APIError"];
+            };
+        };
+    };
     parameters: never;
     requestBodies: never;
     headers: never;

--- a/web/components/NewVendorModelForm.tsx
+++ b/web/components/NewVendorModelForm.tsx
@@ -10,12 +10,12 @@ interface Props {
 }
 
 export default function NewVendorModelForm({ vendorID }: Props) {
-  const mutation = apiClient.useMutation("post", "/vendors/{vendorID}/models");
+  const mutation = apiClient.useMutation("post", "/models");
   const mutate = (body: components["schemas"]["NewModel"]) =>
-    mutation.mutate({ params: { path: { vendorID } }, body });
+    mutation.mutate({ body: { ...body, vendorID } });
 
   if (mutation.isSuccess) {
-    const next = `/models/${mutation.data.id}`;
+    const next = `/vendors/${vendorID}/models/${mutation.data.id}`;
     redirect(next);
   }
 


### PR DESCRIPTION
Instead of using the generated API representations everywhere, we now use our own internal types and convert to the generated API types at the application boundary.

This makes it easier to apply business logic without messing with custom tags and such.

Fixes #14
